### PR TITLE
Fix default messages missing dots

### DIFF
--- a/examples/docs/validators/js/react-final-form/iban-custom-sync-validator/custom-validators/iban.validator.js
+++ b/examples/docs/validators/js/react-final-form/iban-custom-sync-validator/custom-validators/iban.validator.js
@@ -2,7 +2,7 @@ import { parseMessageWithCustomArgs } from '@lemoncode/fonk';
 
 const validatorType = 'MY_IBAN_VALIDATOR';
 
-let defaultMessage = 'IBAN does not belong to {{countryCode}}';
+let defaultMessage = 'IBAN does not belong to {{countryCode}}.';
 export const setErrorMessage = message => (defaultMessage = message);
 
 const hasValidCountryCode = (value, customArgs) =>

--- a/examples/docs/validators/js/vanilla/iban-custom-sync-validator/src/custom-validator.js
+++ b/examples/docs/validators/js/vanilla/iban-custom-sync-validator/src/custom-validator.js
@@ -2,7 +2,7 @@ import { parseMessageWithCustomArgs } from '@lemoncode/fonk';
 
 const validatorType = 'MY_IBAN_VALIDATOR';
 
-let defaultMessage = 'IBAN does not belong to {{countryCode}}';
+let defaultMessage = 'IBAN does not belong to {{countryCode}}.';
 export const setErrorMessage = message => (defaultMessage = message);
 
 const hasValidCountryCode = (value, customArgs) =>

--- a/examples/docs/validators/ts/react-final-form/iban-custom-sync-validator/src/custom-validators/iban.validator.ts
+++ b/examples/docs/validators/ts/react-final-form/iban-custom-sync-validator/src/custom-validators/iban.validator.ts
@@ -5,7 +5,7 @@ import {
 
 const validatorType = 'MY_IBAN_VALIDATOR';
 
-let defaultMessage = 'IBAN does not belong to {{countryCode}}';
+let defaultMessage = 'IBAN does not belong to {{countryCode}}.';
 export const setErrorMessage = message => (defaultMessage = message);
 
 const hasValidCountryCode = (value, customArgs) =>

--- a/examples/docs/validators/ts/vanilla/iban-custom-sync-validator/src/custom-validator.ts
+++ b/examples/docs/validators/ts/vanilla/iban-custom-sync-validator/src/custom-validator.ts
@@ -5,7 +5,7 @@ import {
 
 const validatorType = 'MY_IBAN_VALIDATOR';
 
-let defaultMessage = 'IBAN does not belong to {{countryCode}}';
+let defaultMessage = 'IBAN does not belong to {{countryCode}}.';
 export const setErrorMessage = message => (defaultMessage = message);
 
 const hasValidCountryCode = (value, customArgs) =>

--- a/src/validators/max-length.ts
+++ b/src/validators/max-length.ts
@@ -4,7 +4,7 @@ import { parseMessageWithCustomArgs } from './validators.helpers';
 
 const VALIDATOR_TYPE = 'MAX_LENGTH';
 
-let defaultMessage = 'The value provided does not fulfill max length';
+let defaultMessage = 'The value provided does not fulfill max length.';
 export const setErrorMessage = message => (defaultMessage = message);
 
 const BAD_PARAMETER =

--- a/src/validators/min-length.ts
+++ b/src/validators/min-length.ts
@@ -4,7 +4,7 @@ import { parseMessageWithCustomArgs } from './validators.helpers';
 
 const VALIDATOR_TYPE = 'MIN_LENGTH';
 
-let defaultMessage = 'The value provided does not fulfill min length';
+let defaultMessage = 'The value provided does not fulfill min length.';
 export const setErrorMessage = message => (defaultMessage = message);
 
 const BAD_PARAMETER =


### PR DESCRIPTION
Hello 👋 

I find myself updating messages adding the dots on maxLength & minLength for consistency on my apps.

For example, your `email` validator default message include a dot: "Please enter a valid email address."

While your `minLength` does not: "The value provided does not fulfill min length"

This is clearly a detail, but could save few lines of code for my apps.

I just edited that on all files where the default message was missing its ending dot.

Thanks a lot for your job on fonk, it is a great library!